### PR TITLE
Prevent continuous loading loop

### DIFF
--- a/frontend/routes/sample/sample.js
+++ b/frontend/routes/sample/sample.js
@@ -46,7 +46,7 @@ function DataSamplingController($state, config, RestService, CacheService) {
           if(result.results[0].series && result.results[0].series[0]) {
             seriesLength = result.results[0].series[0].values.length;
           }
-          if(seriesLength < this.minimumNumberOfDataPoints) {
+          if(seriesLength < this.minimumNumberOfDataPoints && timeIncrements.length > 0) {
             tryNextTimeIncrement();
           } else {
             this.series = result.results[0].series[0];


### PR DESCRIPTION
Having only a bunch of measurements available, the GUI hangs up in a continuous loading loop due to `undefined` timeIncrements  – `undefined` gets passed as parameter and triggers:
> "invalid operation: time and *influxql.BinaryExpr are not compatible"